### PR TITLE
Add support for custom list of players;

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 tasks.jar {
   from(rootProject.file("license.txt")) {
-    rename { "license_${rootProject.name.toLowerCase()}.txt" }
+    rename { "license_${rootProject.name.lowercase()}.txt" }
   }
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   api(libs.adventureTextSerializerGson) {
     exclude("com.google.code.gson", "gson")
   }
+  api(libs.adventureTextSerializerLegacy)
   api(libs.minimessage)
   compileOnlyApi(libs.slf4jApi)
   compileOnlyApi(libs.checkerQual)

--- a/common/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTD.java
+++ b/common/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTD.java
@@ -84,24 +84,28 @@ public final class MiniMOTD<I> {
       .disablePlayerListHover(config.disablePlayerListHover())
       .hidePlayerCount(config.hidePlayerCount());
 
-    @Nullable String iconString = null;
+    final MiniMOTDConfig.@Nullable MOTD motdConfig;
+    if (config.motds().isEmpty()) {
+      motdConfig = null;
+    } else {
+      final int index = config.motds().size() == 1 ? 0 : ThreadLocalRandom.current().nextInt(config.motds().size());
+      motdConfig = config.motds().get(index);
+    }
+
     if (config.motdEnabled()) {
-      if (config.motds().isEmpty()) {
+      if (motdConfig == null) {
         throw new IllegalStateException("MOTD is enabled, but there are no MOTDs in the config file?");
       }
-      final int index = config.motds().size() == 1 ? 0 : ThreadLocalRandom.current().nextInt(config.motds().size());
-      final MiniMOTDConfig.MOTD motdConfig = config.motds().get(index);
       final Component motd = Components.ofChildren(
         parse(motdConfig.line1(), count),
         newline(),
         parse(motdConfig.line2(), count)
       );
       response.motd(motd);
-      iconString = motdConfig.icon();
     }
 
     if (config.iconEnabled()) {
-      response.icon(this.iconManager().icon(iconString));
+      response.icon(this.iconManager().icon(motdConfig == null ? null : motdConfig.icon()));
     }
 
     return response.build();

--- a/common/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTD.java
+++ b/common/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTD.java
@@ -25,10 +25,12 @@ package xyz.jpenilla.minimotd.common;
 
 import java.nio.file.Path;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -106,6 +108,16 @@ public final class MiniMOTD<I> {
 
     if (config.iconEnabled()) {
       response.icon(this.iconManager().icon(motdConfig == null ? null : motdConfig.icon()));
+    }
+
+    if (config.hoverEnabled()) {
+      if (config.disablePlayerListHover() || config.hidePlayerCount()) {
+        throw new IllegalStateException("Hover enabled requires setting `disable-player-list-hover` and `hide-player-count` to false!");
+      }
+      response.hover(motdConfig == null ? null : motdConfig.hover().stream()
+        .map(MiniMessage.miniMessage()::deserialize)
+        .map(LegacyComponentSerializer.legacySection()::serialize)
+        .collect(Collectors.toList()));
     }
 
     return response.build();

--- a/common/src/main/java/xyz/jpenilla/minimotd/common/PingResponse.java
+++ b/common/src/main/java/xyz/jpenilla/minimotd/common/PingResponse.java
@@ -23,6 +23,7 @@
  */
 package xyz.jpenilla.minimotd.common;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import net.kyori.adventure.text.Component;
@@ -37,6 +38,7 @@ public final class PingResponse<I> {
   private final @Nullable I icon;
   private final @Nullable Component motd;
   private final PlayerCount playerCount;
+  private final @Nullable List<String> hover;
   private final boolean hidePlayerCount;
   private final boolean disablePlayerListHover;
 
@@ -44,12 +46,14 @@ public final class PingResponse<I> {
     final @Nullable I icon,
     final @Nullable Component motd,
     final PlayerCount playerCount,
+    final @Nullable List<String> hover,
     final boolean hidePlayerCount,
     final boolean disablePlayerListHover
   ) {
     this.icon = icon;
     this.motd = motd;
     this.playerCount = playerCount;
+    this.hover = hover;
     this.hidePlayerCount = hidePlayerCount;
     this.disablePlayerListHover = disablePlayerListHover;
   }
@@ -98,11 +102,22 @@ public final class PingResponse<I> {
     return this.disablePlayerListHover;
   }
 
+  public @Nullable List<String> hover() {
+    return this.hover;
+  }
+
+  public void hover(final Consumer<List<String>> consumer) {
+    if (this.hover != null) {
+      consumer.accept(this.hover);
+    }
+  }
+
   public Builder<I> toBuilder() {
     return new BuilderImpl<>(
       this.motd,
       this.icon,
       this.playerCount,
+      this.hover,
       this.hidePlayerCount,
       this.disablePlayerListHover
     );
@@ -146,6 +161,8 @@ public final class PingResponse<I> {
 
     Builder<I> playerCount(PlayerCount playerCount);
 
+    Builder<I> hover(@Nullable List<String> playerNames);
+
     Builder<I> hidePlayerCount(boolean hidePlayerCount);
 
     Builder<I> disablePlayerListHover(boolean disablePlayerListHover);
@@ -157,6 +174,7 @@ public final class PingResponse<I> {
     private @Nullable Component motd;
     private @Nullable I icon;
     private @Nullable PlayerCount playerCount;
+    private @Nullable List<String> hover;
     private boolean hidePlayerCount = false;
     private boolean disablePlayerListHover = false;
 
@@ -167,12 +185,14 @@ public final class PingResponse<I> {
       final @Nullable Component motd,
       final @Nullable I icon,
       final @Nullable PlayerCount playerCount,
+      final @Nullable List<String> hover,
       final boolean hidePlayerCount,
       final boolean disablePlayerListHover
     ) {
       this.motd = motd;
       this.icon = icon;
       this.playerCount = playerCount;
+      this.hover = hover;
       this.hidePlayerCount = hidePlayerCount;
       this.disablePlayerListHover = disablePlayerListHover;
     }
@@ -196,6 +216,12 @@ public final class PingResponse<I> {
     }
 
     @Override
+    public Builder<I> hover(final @Nullable List<String> hover) {
+      this.hover = hover;
+      return this;
+    }
+
+    @Override
     public Builder<I> hidePlayerCount(final boolean hidePlayerCount) {
       this.hidePlayerCount = hidePlayerCount;
       return this;
@@ -214,6 +240,7 @@ public final class PingResponse<I> {
         this.icon,
         this.motd,
         this.playerCount,
+        this.hover,
         this.hidePlayerCount,
         this.disablePlayerListHover
       );

--- a/common/src/main/java/xyz/jpenilla/minimotd/common/config/MiniMOTDConfig.java
+++ b/common/src/main/java/xyz/jpenilla/minimotd/common/config/MiniMOTDConfig.java
@@ -59,6 +59,10 @@ public final class MiniMOTDConfig {
   @Comment("Enable server list icon related features")
   private boolean iconEnabled = true;
 
+  @Comment("Setting this to true will changes the text of the player list\n"
+    + "Requires setting `disablePlayerListHover` and `hidePlayerCount` to false")
+  private boolean hoverEnabled = false;
+
   private PlayerCountSettings playerCountSettings = new PlayerCountSettings();
 
   @ConfigSerializable
@@ -82,6 +86,9 @@ public final class MiniMOTDConfig {
       + "    ex: icon=\"myIconFile\"")
     private String icon = "random";
 
+    @Comment("Lines of text will shown when hovering over the online counter")
+    private List<String> hover = Arrays.asList("<green>Player", "<yellow>List");
+
     public @NonNull String line1() {
       return this.line1;
     }
@@ -94,6 +101,9 @@ public final class MiniMOTDConfig {
       return this.icon;
     }
 
+    public @NonNull List<String> hover() {
+      return this.hover;
+    }
   }
 
   @ConfigSerializable
@@ -167,6 +177,10 @@ public final class MiniMOTDConfig {
 
   public boolean motdEnabled() {
     return this.motdEnabled;
+  }
+
+  public boolean hoverEnabled() {
+    return this.hoverEnabled;
   }
 
   public boolean disablePlayerListHover() {

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -50,6 +50,9 @@ dependencies:
   adventureTextSerializerGson:
     group: net.kyori
     name: adventure-text-serializer-gson
+  adventureTextSerializerLegacy:
+    group: net.kyori
+    name: adventure-text-serializer-legacy
   adventurePlatformBungeecord:
     group: net.kyori
     name: adventure-platform-bungeecord

--- a/platform/bukkit/src/main/java/xyz/jpenilla/minimotd/bukkit/PaperPingListener.java
+++ b/platform/bukkit/src/main/java/xyz/jpenilla/minimotd/bukkit/PaperPingListener.java
@@ -25,7 +25,9 @@ package xyz.jpenilla.minimotd.bukkit;
 
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import io.papermc.lib.PaperLib;
+import java.util.UUID;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.util.CachedServerIcon;
@@ -58,6 +60,10 @@ public final class PaperPingListener implements Listener {
       }
     });
     response.icon(event::setServerIcon);
+    response.hover(lines -> {
+      event.getPlayerSample().clear();
+      lines.forEach(name -> event.getPlayerSample().add(Bukkit.createProfile(UUID.randomUUID(), name)));
+    });
 
     if (response.disablePlayerListHover()) {
       event.getPlayerSample().clear();

--- a/platform/bungeecord/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
+++ b/platform/bungeecord/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
@@ -23,6 +23,7 @@
  */
 package xyz.jpenilla.minimotd.bungee;
 
+import java.util.UUID;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ServerPing;
@@ -61,6 +62,12 @@ public final class PingListener implements Listener {
       mini.playerCount().applyCount(players::setOnline, players::setMax);
       if (mini.disablePlayerListHover()) {
         players.setSample(new ServerPing.PlayerInfo[]{});
+      } else {
+        mini.hover(strings -> players.setSample(
+          strings.stream()
+            .map(name -> new ServerPing.PlayerInfo(name, UUID.randomUUID()))
+            .toArray(ServerPing.PlayerInfo[]::new)
+        ));
       }
     }
 

--- a/platform/sponge7/build.gradle.kts
+++ b/platform/sponge7/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 tasks {
   processResources {
     val replacements = mapOf(
-      "modid" to rootProject.name.toLowerCase(Locale.ENGLISH),
+      "modid" to rootProject.name.lowercase(Locale.ENGLISH),
       "name" to rootProject.name,
       "version" to project.version.toString(),
       "description" to project.description.toString(),

--- a/platform/sponge7/src/main/java/xyz/jpenilla/minimotd/sponge7/ClientPingServerEventListener.java
+++ b/platform/sponge7/src/main/java/xyz/jpenilla/minimotd/sponge7/ClientPingServerEventListener.java
@@ -24,11 +24,13 @@
 package xyz.jpenilla.minimotd.sponge7;
 
 import com.google.inject.Inject;
+import java.util.UUID;
 import net.kyori.adventure.text.serializer.spongeapi.SpongeComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.event.EventListener;
 import org.spongepowered.api.event.server.ClientPingServerEvent;
 import org.spongepowered.api.network.status.Favicon;
+import org.spongepowered.api.profile.GameProfile;
 import xyz.jpenilla.minimotd.common.MiniMOTD;
 import xyz.jpenilla.minimotd.common.PingResponse;
 import xyz.jpenilla.minimotd.common.config.MiniMOTDConfig;
@@ -64,6 +66,9 @@ final class ClientPingServerEventListener implements EventListener<ClientPingSer
     mini.playerCount().applyCount(players::setOnline, players::setMax);
     mini.motd(motd -> response.setDescription(SpongeComponentSerializer.get().serialize(motd)));
     mini.icon(response::setFavicon);
+    mini.hover(strings -> strings.forEach(name ->
+      players.getProfiles().add(GameProfile.of(UUID.randomUUID(), name))
+    ));
 
     if (mini.disablePlayerListHover()) {
       players.getProfiles().clear();

--- a/platform/sponge8/src/main/java/xyz/jpenilla/minimotd/sponge8/ClientPingServerEventListener.java
+++ b/platform/sponge8/src/main/java/xyz/jpenilla/minimotd/sponge8/ClientPingServerEventListener.java
@@ -25,11 +25,13 @@ package xyz.jpenilla.minimotd.sponge8;
 
 import com.google.inject.Inject;
 import java.lang.reflect.Method;
+import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.MinecraftVersion;
 import org.spongepowered.api.event.EventListener;
 import org.spongepowered.api.event.server.ClientPingServerEvent;
 import org.spongepowered.api.network.status.Favicon;
+import org.spongepowered.api.profile.GameProfile;
 import xyz.jpenilla.minimotd.common.Constants;
 import xyz.jpenilla.minimotd.common.MiniMOTD;
 import xyz.jpenilla.minimotd.common.PingResponse;
@@ -84,6 +86,9 @@ final class ClientPingServerEventListener implements EventListener<ClientPingSer
       }
     });
     mini.icon(response::setFavicon);
+    mini.hover(strings -> strings.forEach(name ->
+      players.profiles().add(GameProfile.of(UUID.randomUUID(), name))
+    ));
 
     if (mini.disablePlayerListHover()) {
       players.profiles().clear();

--- a/platform/velocity/src/main/java/xyz/jpenilla/minimotd/velocity/PingListener.java
+++ b/platform/velocity/src/main/java/xyz/jpenilla/minimotd/velocity/PingListener.java
@@ -28,7 +28,9 @@ import com.velocitypowered.api.event.EventTask;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyPingEvent;
 import com.velocitypowered.api.proxy.server.ServerPing;
+import com.velocitypowered.api.proxy.server.ServerPing.SamplePlayer;
 import com.velocitypowered.api.util.Favicon;
+import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.minimotd.common.MiniMOTD;
@@ -57,6 +59,12 @@ public final class PingListener {
     response.icon(pong::favicon);
     response.motd(pong::description);
     response.playerCount().applyCount(pong::onlinePlayers, pong::maximumPlayers);
+    response.hover(strings -> {
+      pong.clearSamplePlayers();
+      pong.samplePlayers(strings.stream().map(name ->
+        new SamplePlayer(name, UUID.randomUUID())
+      ).toArray(SamplePlayer[]::new));
+    });
 
     if (response.disablePlayerListHover()) {
       pong.clearSamplePlayers();


### PR DESCRIPTION
Adds the implementation of a custom player list (`hover`), shown when hovering over the online.
May contain not very elegant solutions.
Tested on platforms: Paper, Velocity.