### PR TITLE
Implement Paper platform

### DIFF
--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -32,3 +32,5 @@ val bukkitVersions = listOf(
   "1.19.4",
   "1.20.1"
 )
+
+val paperVersions = bukkitVersions.subList(12, bukkitVersions.size-1)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
   id("minimotd.build-logic")
+  id("xyz.jpenilla.run-paper") apply false
 }

--- a/platform/bukkit/src/main/java/xyz/jpenilla/minimotd/bukkit/MiniMOTDPlugin.java
+++ b/platform/bukkit/src/main/java/xyz/jpenilla/minimotd/bukkit/MiniMOTDPlugin.java
@@ -26,6 +26,7 @@ package xyz.jpenilla.minimotd.bukkit;
 import io.papermc.lib.PaperLib;
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bstats.bukkit.Metrics;
@@ -42,6 +43,7 @@ import xyz.jpenilla.minimotd.common.util.UpdateChecker;
 
 public final class MiniMOTDPlugin extends JavaPlugin implements MiniMOTDPlatform<CachedServerIcon> {
   private static final boolean PAPER_PING_EVENT_EXISTS = findClass("com.destroystokyo.paper.event.server.PaperServerListPingEvent") != null;
+  private static final boolean MODERN_PAPER = findClass("io.papermc.paper.plugin.configuration.PluginMeta") != null;
 
   private Logger logger;
   private MiniMOTD<CachedServerIcon> miniMOTD;
@@ -52,6 +54,20 @@ public final class MiniMOTDPlugin extends JavaPlugin implements MiniMOTDPlatform
     this.logger = LoggerFactory.getLogger(this.getName());
     this.miniMOTD = new MiniMOTD<>(this);
     this.audiences = BukkitAudiences.create(this);
+
+    if (MODERN_PAPER) {
+      this.logger.warn(String.join("\n", Arrays.asList(
+        "",
+        "====================================================",
+        "You are using an unoptimized version of MiniMOTD for your server.",
+        "",
+        "MiniMOTD has an exclusive version for Paper 1.19.4 and higher",
+        "with performance improvements and use of native functions.",
+        "",
+        "Download MiniMOTD Paper from https://hangar.papermc.io/jmp/MiniMOTD",
+        "===================================================="
+      )));
+    }
 
     if (PAPER_PING_EVENT_EXISTS) {
       this.getServer().getPluginManager().registerEvents(new PaperPingListener(this.miniMOTD), this);

--- a/platform/paper/build.gradle.kts
+++ b/platform/paper/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+  id("minimotd.shadow-platform")
+  id("xyz.jpenilla.run-paper")
+}
+
+dependencies {
+  implementation(projects.minimotdCommon)
+  implementation(libs.bstatsBukkit)
+  compileOnly(libs.paperApi)
+}
+
+tasks {
+  runServer {
+    minecraftVersion(minecraftVersion)
+  }
+  shadowJar {
+    configureForNativeAdventurePlatform()
+    commonRelocation("org.bstats")
+    dependencies {
+      // Already included in Paper 1.18.2+
+      exclude(dependency("io.leangen.geantyref:geantyref"))
+    }
+  }
+  processResources {
+    filesMatching("paper-plugin.yml") {
+      expand("version" to version)
+    }
+  }
+}
+
+modrinth {
+  gameVersions.addAll(paperVersions)
+}

--- a/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/MiniMOTDPlugin.java
+++ b/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/MiniMOTDPlugin.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of MiniMOTD, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2023 Jason Penilla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package xyz.jpenilla.minimotd.paper;
+
+import java.awt.image.BufferedImage;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import org.bstats.bukkit.Metrics;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.CachedServerIcon;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import xyz.jpenilla.minimotd.common.MiniMOTD;
+import xyz.jpenilla.minimotd.common.MiniMOTDPlatform;
+import xyz.jpenilla.minimotd.common.util.UpdateChecker;
+
+public class MiniMOTDPlugin extends JavaPlugin implements MiniMOTDPlatform<CachedServerIcon> {
+  private Logger logger;
+  private MiniMOTD<CachedServerIcon> miniMOTD;
+
+  @Override
+  public void onEnable() {
+    this.logger = this.getSLF4JLogger();
+    this.miniMOTD = new MiniMOTD<>(this);
+
+    this.getServer().getPluginManager().registerEvents(new PingListener(this.miniMOTD), this);
+
+    final PaperCommand command = new PaperCommand(this);
+    this.getServer().getCommandMap().register("minimotd", command);
+
+    new Metrics(this, 8132);
+
+    if (this.miniMOTD.configManager().pluginSettings().updateChecker()) {
+      try {
+        Entity.class.getDeclaredMethod("getScheduler");
+        CompletableFuture.runAsync(() -> new UpdateChecker().checkVersion().forEach(this.logger::info)).whenComplete(($, thr) -> {
+          if (thr != null) {
+            this.logger.warn("Exception checking for updates", thr);
+          }
+        });
+      } catch (final ReflectiveOperationException ex) {
+        this.getServer().getScheduler().runTaskAsynchronously(this, () ->
+          new UpdateChecker().checkVersion().forEach(this.logger::info));
+      }
+    }
+  }
+
+  public @NonNull MiniMOTD<CachedServerIcon> miniMOTD() {
+    return this.miniMOTD;
+  }
+
+  @Override
+  public @NonNull Path dataDirectory() {
+    return this.getDataFolder().toPath();
+  }
+
+  @Override
+  public @NonNull Logger logger() {
+    return this.logger;
+  }
+
+  @Override
+  public @NonNull CachedServerIcon loadIcon(final @NonNull BufferedImage image) throws Exception {
+    return this.getServer().loadServerIcon(image);
+  }
+}

--- a/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/PaperCommand.java
+++ b/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/PaperCommand.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of MiniMOTD, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2023 Jason Penilla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package xyz.jpenilla.minimotd.paper;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+import xyz.jpenilla.minimotd.common.CommandHandler;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.event.ClickEvent.runCommand;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+
+public final class PaperCommand extends Command implements PluginIdentifiableCommand {
+  private final MiniMOTDPlugin plugin;
+  private final CommandHandler handler;
+
+  PaperCommand(final MiniMOTDPlugin plugin) {
+    super("minimotd", "MiniMOTD Command", "/minimotd help", Collections.emptyList());
+    this.plugin = plugin;
+    this.handler = new CommandHandler(plugin.miniMOTD());
+  }
+
+  @Override
+  public boolean execute(final @NotNull CommandSender sender, final @NotNull String commandLabel, final @NotNull String[] args) {
+    if (!sender.hasPermission("minimotd.admin")) {
+      sender.sendMessage(text("No permission.", RED));
+      return true;
+    }
+
+    if (args.length == 0) {
+      this.onInvalidUse(sender);
+      return true;
+    }
+
+    switch (args[0]) {
+      case "about":
+        this.handler.about(sender);
+        return true;
+      case "help":
+        this.handler.help(sender);
+        return true;
+      case "reload":
+        this.handler.reload(sender);
+        return true;
+    }
+
+    this.onInvalidUse(sender);
+    return true;
+  }
+
+  @Override
+  public @NotNull Plugin getPlugin() {
+    return this.plugin;
+  }
+
+  private void onInvalidUse(final @NonNull Audience audience) {
+    audience.sendMessage(text("Invalid command usage. Use '/minimotd help' for a list of command provided by MiniMOTD.", RED)
+      .hoverEvent(text("Click to execute '/minimotd help'"))
+      .clickEvent(runCommand("/minimotd help")));
+  }
+
+  private static final List<String> COMMANDS = ImmutableList.of("about", "reload", "help");
+
+  @Override
+  public @NotNull List<String> tabComplete(final @NonNull CommandSender sender, final @NonNull String alias, final @NonNull String[] args) {
+    if (args.length < 2 && sender.hasPermission("minimotd.admin")) {
+      return COMMANDS;
+    }
+    return Collections.emptyList();
+  }
+
+}

--- a/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/PingListener.java
+++ b/platform/paper/src/main/java/xyz/jpenilla/minimotd/paper/PingListener.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of MiniMOTD, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2023 Jason Penilla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package xyz.jpenilla.minimotd.paper;
+
+import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.util.CachedServerIcon;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import xyz.jpenilla.minimotd.common.Constants;
+import xyz.jpenilla.minimotd.common.MiniMOTD;
+import xyz.jpenilla.minimotd.common.PingResponse;
+import xyz.jpenilla.minimotd.common.config.MiniMOTDConfig;
+import xyz.jpenilla.minimotd.common.util.ComponentColorDownsampler;
+
+class PingListener implements Listener {
+  private final MiniMOTD<CachedServerIcon> miniMOTD;
+
+  PingListener(final @NonNull MiniMOTD<CachedServerIcon> miniMOTD) {
+    this.miniMOTD = miniMOTD;
+  }
+
+  @EventHandler
+  public void handlePing(final @NonNull PaperServerListPingEvent event) {
+    final MiniMOTDConfig cfg = this.miniMOTD.configManager().mainConfig();
+
+    final PingResponse<CachedServerIcon> response = this.miniMOTD.createMOTD(cfg, event.getNumPlayers(), event.getMaxPlayers());
+
+    response.playerCount().applyCount(event::setNumPlayers, event::setMaxPlayers);
+    response.motd(motd -> {
+      if (event.getClient().getProtocolVersion() < Constants.MINECRAFT_1_16_PROTOCOL_VERSION) {
+        event.motd(ComponentColorDownsampler.downsampler().downsample(motd));
+      } else {
+        event.motd(motd);
+      }
+    });
+
+    response.icon(event::setServerIcon);
+
+    if (response.disablePlayerListHover()) {
+      event.getPlayerSample().clear();
+    }
+    if (response.hidePlayerCount()) {
+      event.setHidePlayers(true);
+    }
+  }
+}

--- a/platform/paper/src/main/resources/paper-plugin.yml
+++ b/platform/paper/src/main/resources/paper-plugin.yml
@@ -1,0 +1,7 @@
+name: MiniMOTD
+version: '${version}'
+author: jmp
+description: Use MiniMessage text formatting in the server list MOTD.
+main: xyz.jpenilla.minimotd.paper.MiniMOTDPlugin
+api-version: '1.19'
+folia-supported: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ pluginManagement {
 plugins {
   id("ca.stellardrift.polyglot-version-catalogs") version "6.0.1"
   id("quiet-fabric-loom") version "1.2-SNAPSHOT"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.6.0"
 }
 
 rootProject.name = "MiniMOTD"
@@ -43,6 +44,7 @@ setup("minimotd-common", "common")
 
 sequenceOf(
   "bukkit",
+  "paper",
   "sponge8",
   "sponge7",
   "bungeecord",


### PR DESCRIPTION
Implemented a new module exclusive to Paper 1.19.4+

This module allows to use Paper API directly, without using AdventurePlatformBukkit as an intermediary to use Adventure.
Also removed the use of the LegacyComponentSerializer as it is no longer needed

#131 