### PR TITLE
darkstarworks velocity patch 1.1

### DIFF
--- a/common/src/main/java/xyz/jpenilla/minimotd/common/config/MOTDConfig.java
+++ b/common/src/main/java/xyz/jpenilla/minimotd/common/config/MOTDConfig.java
@@ -59,6 +59,10 @@ public final class MOTDConfig {
   @Comment("Enable server list icon related features")
   private boolean iconEnabled = true;
 
+  @Comment("Enable offline MOTD when all servers are offline\n"
+  + "Requires offline-config.conf file to be present")
+  private boolean useOfflineMotd = false;
+
   private PlayerCountSettings playerCountSettings = new PlayerCountSettings();
 
   @ConfigSerializable
@@ -214,5 +218,9 @@ public final class MOTDConfig {
       return playerCount(Math.min(online, max), max);
     }
     return playerCount(online, max);
+  }
+
+  public boolean useOfflineMotd() {
+    return this.useOfflineMotd;
   }
 }


### PR DESCRIPTION
Adding a Velocity feature to change the MOTD when all servers are offline

Key Changes:

- Add offline config loader through `offlineConfig` in the ConfigManager
-- that is created as `offline-config.conf`, where the offline MOTD is set:
```# MiniMOTD Offline Configuration
   # This configuration is used when all backend servers are offline.
   # To enable this feature, set 'use-offline-motd=true' in main.conf
   
   motds=[
     {
       icon=random
       line1="<red><bold>⚠ SERVER OFFLINE ⚠"
       line2="<gray>We're currently performing maintenance!"
     }
   ]
   # ... (all other MOTDConfig fields)
```

- Add support for hocon boolean in `main.conf` through `boolean useOfflineMotd` in MOTDConfig:
```
   # Enable offline MOTD when all servers are offline
   # Requires offline-config.conf file to be present

   use-offline-motd=false
```